### PR TITLE
增加对 antvG6的解析

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,12 @@
           "version": "^2.0.0",
           "reason": "https://github.com/toji/gl-matrix/blob/v2.4.0/src/gl-matrix/common.js#L27"
         }
+      },
+      "@antv/g6": {
+        "^2.0.2": {
+          "version": "^2.0.2",
+          "reason": "see https://github.com/antvis/g6/blob/master/plugins/tool.minimap/index.js#L18"
+        }
       }
     }
   }


### PR DESCRIPTION
```
      "@antv/g6": {
        "^2.0.2": {
          "version": "^2.0.2",
          "reason": "see https://github.com/antvis/g6/blob/master/plugins/tool.minimap/index.js#L18"
        }
      }
```