### PR TITLE
feat: Add autobind-decorator ^2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,12 @@
           "version": "^3.1.1",
           "reason": "https://github.com/ericnorris/striptags/blob/master/src/striptags.js#L14"
         }
+      },
+      "autobind-decorator": {
+        "^2.2.0": {
+          "version": "^2.2.0",
+          "reason": "https://github.com/andreypopp/autobind-decorator/blob/master/src/index.js#L6 + https://github.com/andreypopp/autobind-decorator/blob/master/package.json#L6"
+        }
       }
     }
   }


### PR DESCRIPTION
- `autobind-decorator ^2.2.0` added `module` field in `package.json` to support `ES modules`. As the result, when we import autobind-decorator, `src/index.js` will be the entry that contains `ES6` syntax.
- ref: https://github.com/andreypopp/autobind-decorator/blob/master/package.json#L6