### PR TITLE
supermap plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/package.json
+++ b/package.json
@@ -338,6 +338,18 @@
           "version": "*",
           "reason": "https://github.com/react-spring/react-spring"
         }
+      },
+      "@supermap/iclient-common": {
+        "*": {
+          "version": "*",
+          "reason": "https://github.com/SuperMap/iClient-JavaScript/blob/master/src/common/index.js#L4"
+        }
+      },
+      "@supermap/iclient-leaflet": {
+        "*": {
+          "version": "*",
+          "reason": "https://github.com/SuperMap/iClient-JavaScript/blob/master/src/leaflet/index.js#L4"
+        }
       }
     }
   }


### PR DESCRIPTION
超图的两个插件需要es6语法转义。
官方文档上（打包配置）有如下说明：
http://iclient.supermap.io/web/introduction/leafletDevelop.html#Ready。
具体reason在PR中。