### PR TITLE
由于iClient对Elastsupermap-icsearch的API进行了封装而Elasticsearch也使用了ES6的语法

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,6 +356,12 @@
           "version": "^2.29.5",
           "reason": "https://github.com/spritejs/spritejs/blob/master/dist/spritejs.esm.js#L3928"
         }
+      },
+      "elasticsearch": {
+        "*": {
+          "version": "*",
+          "reason": "https://github.com/elastic/elasticsearch-js/blob/master/lib/Serializer.js#L11"
+        }
       }
     }
   }


### PR DESCRIPTION
由于iClient对Elastsupermap-icsearch的API进行了封装而Elasticsearch也使用了ES6的语法,之前超图（supermap）已经提交过相关PR。
[相关介绍](http://iclient.supermap.io/web/introduction/leafletDevelop.html#Ready)

![image](https://user-images.githubusercontent.com/18083432/67648875-e29be900-f971-11e9-99a9-b28a0bcf8912.png)
