### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,18 @@
   "homepage": "https://github.com/umijs/es5-imcompatible-versions#readme",
   "config": {
     "es5-imcompatible-versions": {
+      "@umijs/utils": {
+        "^3.2.16": {
+          "version": "^3.2.16",
+          "reason": "see https://github.com/umijs/umi/blob/master/packages/utils/src/ssr.ts"
+        }
+      },
+      "@umijs/bundler-webpack": {
+        "^3.2.16": {
+          "version": "^3.2.16",
+          "reason": "see https://github.com/umijs/umi/blob/master/packages/bundler-webpack/src/getConfig/runtimePublicPathEntry.ts"
+        }
+      },
       "seinjs": {
         "^1.1.14": {
           "version": "^1.1.14",


### PR DESCRIPTION
新增配置： @umijs/utils，@umijs/bundler-webpack
@umijs/utils：ssr.ts文件进行es5转换的时候，箭头函数未成功转换
@umijs/bundler-webpack：runtimePublicPathEntry.ts文件进行es5转换的时候，对react的声明依然使用的const关键字