### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -456,6 +456,18 @@
           "version": "^3.1.18",
           "reason": "https://github.com/ai/nanoid#ie"
         }
+      },
+      "fast-deep-equal": {
+        "^3.1.3": {
+          "version": "^3.1.3",
+          "reason": "https://github.com/epoberezkin/fast-deep-equal#fast-deep-equal"
+        }
+      },
+      "jssha": {
+        "^3.1.2": {
+          "version": "^3.1.2",
+          "reason": "https://github.com/Caligatio/jsSHA"
+        }
       }
     }
   }


### PR DESCRIPTION
fast-deep-equal:To support ES6 Maps
jssha:The minified ECMAScript 2015 (ES6) compatible ESM version of the library with support for all hash variants. Its accompanying source map can be found in dist/sha.mjs.map and its TypeScript declarations in dist/sha.d.ts.