### PR TITLE
Reduce the range of date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -470,8 +470,8 @@
         }
       },
       "date-fns": {
-        "^2.21.2": {
-          "version": "^2.21.2",
+        "~2.21.2": {
+          "version": "~2.21.2",
           "reason": "https://github.com/date-fns/date-fns/blob/v2.21.2/src/_lib/format/lightFormatters/index.ts#L18"
         }
       },


### PR DESCRIPTION
`date-fns` team has fixed the imcompatible issue at `2.21.3`.