### PR TITLE
antd-mobile 5.x 兼容

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
   "homepage": "https://github.com/umijs/es5-imcompatible-versions#readme",
   "config": {
     "es5-imcompatible-versions": {
+      "antd-mobile": {
+        "^5.21.0": {
+          "version": "^5.21.0",
+          "reason": "see https://github.com/ant-design/ant-design-mobile"
+        }
+      },
       "fuse.js": {
         "^6.4.6": {
           "version": "^6.4.6",


### PR DESCRIPTION
由于 antd-mobile 5.x 在 roadhog 环境下，打包的时候开启了按需加载的话，会导致 uglifyjs 错误