### PR TITLE
[WIP] feat: add apache-arrow@<5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -545,6 +545,12 @@
           "version": "1.5.0",
           "reason": "https://github.com/soldair/node-qrcode/blob/f08fd572d7cca92c8b9d71b24cebccf61663d4a6/lib/core/byte-data.js#L22"
         }
+      },
+      "apache-arrow": {
+        "<5.0.0": {
+          "version": "<5.0.0",
+          "reason": "https://github.com/apache/arrow/commit/93bdbf1df56ffd33af10de104c68cdcb85e54fa5#diff-078af6b8801d0e03590b0311cc2d27e8663bb98bd9c927977d208c6ee1211198R70-R71"
+        }
       }
     }
   }


### PR DESCRIPTION
近期 Bigfish 项目 esbuild 压缩报错的来源（之一？），该包在 5.0.0 之前的构建 target 为 `esnext`，所以产物里出现了 async generator 导致压缩报错