### PR TITLE
feat: add ip-bigint

### DIFF
--- a/package.json
+++ b/package.json
@@ -557,6 +557,12 @@
           "version": "^4.12.0",
           "reason": "https://github.com/panva/jose/blob/bba48249db55cb9ce86e739595ef53bf3422cced/dist/browser/jwks/local.js#L85"
         }
+      },
+      "ip-bigint": {
+        ">1.0.0": {
+          "version": ">1.0.0",
+          "reason": "https://github.com/silverwind/ip-bigint/blob/6.0.0/index.js#L20"
+        }
       }
     }
   }


### PR DESCRIPTION
BigInt 会导致 esbuild 压缩报错：

```bash
ERROR: Big integer literals are not available in the configured target environment ("chrome80", "es2015")
```