### PR TITLE
feat: add @aws-sdk/{eventstream-serde-universal,eventstream-serde-browser}@^3.183.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -557,6 +557,18 @@
           "version": "^4.12.0",
           "reason": "https://github.com/panva/jose/blob/bba48249db55cb9ce86e739595ef53bf3422cced/dist/browser/jwks/local.js#L85"
         }
+      },
+      "@aws-sdk/eventstream-serde-browser": {
+        "^3.183.0": {
+          "version": "^3.183.0",
+          "reason": "https://github.com/aws/aws-sdk-js-v3/commit/6a7fea46868573538cf76f3541d873027b54c0b0"
+        }
+      },
+      "@aws-sdk/eventstream-serde-universal": {
+        "^3.183.0": {
+          "version": "^3.183.0",
+          "reason": "https://github.com/aws/aws-sdk-js-v3/commit/6a7fea46868573538cf76f3541d873027b54c0b0"
+        }
       }
     }
   }


### PR DESCRIPTION
添加 @aws-sdk 下的两个包，目前 OB 有用到，从 3.183.0 开始更新了 target 输出 es2020 的产物了