### PR TITLE
feat: add valtio

### DIFF
--- a/package.json
+++ b/package.json
@@ -623,6 +623,12 @@
           "version": "^4.4.0",
           "reason": "https://github.com/exceljs/exceljs/blob/master/.browserslistrc#L1"
         }
+      },
+      "valtio": {
+        "*": {
+          "version": "*",
+          "reason": "https://github.com/pmndrs/valtio/blob/main/src/vanilla.ts#L393"
+        }
       }
     }
   }


### PR DESCRIPTION
fix: chrome 65 及以下不支持 optional catch binding 语法